### PR TITLE
Merge fold and subsequent reduce operations on iterator

### DIFF
--- a/src/scheduler/scheduler_impl.rs
+++ b/src/scheduler/scheduler_impl.rs
@@ -507,8 +507,7 @@ mod parallel_rt_impl {
 
                 CloneableCtx(ctx)
             })
-            .fold(|| RContextForwardableStuff::default(), |cx1, cx2| cx1.merge(cx2.0.insides))
-            .reduce(|| Default::default(), RContextForwardableStuff::merge);
+            .reduce(|| RContextForwardableStuff::default(), |cx1, cx2| cx1.merge(cx2.0.insides));
     }
 
     #[derive(Copy, Clone)]


### PR DESCRIPTION
`fold_with` followed by `fold` followed by `reduce` doesn't make sense to me, so I've merged the last two operations. Seems to improve performance.