### PR TITLE
Plan x and y should be swapped when level of x < level of y

### DIFF
--- a/src/scheduler/dependencies.rs
+++ b/src/scheduler/dependencies.rs
@@ -694,7 +694,7 @@ impl<'x> ExecutableReactions<'x> {
                 Some(Cow::Owned(x))
             }
             (Some(mut x), Some(mut y)) => {
-                if x.max_level() > y.max_level() {
+                if x.max_level() < y.max_level() {
                     std::mem::swap(&mut x, &mut y);
                 }
                 // x is the largest one here


### PR DESCRIPTION
This comparison should be the other way around, as the comment on line 700 says. Casual benchmarking doesn't show improved performance, but that could be because the only working parallel benchmark is RadixSort, which might not need to merge plans after parallel execution.