### PR TITLE
Properly merge RContextForwardableStuff

### DIFF
--- a/src/scheduler/context.rs
+++ b/src/scheduler/context.rs
@@ -554,11 +554,11 @@ impl Default for RContextForwardableStuff<'_> {
 #[cfg(feature = "parallel-runtime")]
 impl RContextForwardableStuff<'_> {
     pub(super) fn merge(mut self, other: Self) -> Self {
-        self.merge_in_place(other);
+        self.absorb(other);
         self
     }
 
-    pub(super) fn merge_in_place(&mut self, mut other: Self) {
+    pub(super) fn absorb(&mut self, mut other: Self) {
         self.todo_now = ExecutableReactions::merge_cows(self.todo_now.take(), other.todo_now);
         self.future_events.append(&mut other.future_events);
     }

--- a/src/scheduler/context.rs
+++ b/src/scheduler/context.rs
@@ -558,6 +558,11 @@ impl RContextForwardableStuff<'_> {
         self.future_events.append(&mut other.future_events);
         self
     }
+
+    pub(super) fn merge_in_place(&mut self, mut other: Self) {
+        self.todo_now = ExecutableReactions::merge_cows(self.todo_now.clone(), other.todo_now);
+        self.future_events.append(&mut other.future_events);
+    }
 }
 
 /// A type that can affect the logical event queue to implement

--- a/src/scheduler/context.rs
+++ b/src/scheduler/context.rs
@@ -553,14 +553,13 @@ impl Default for RContextForwardableStuff<'_> {
 
 #[cfg(feature = "parallel-runtime")]
 impl RContextForwardableStuff<'_> {
-    pub(super) fn merge(mut self, mut other: Self) -> Self {
-        self.todo_now = ExecutableReactions::merge_cows(self.todo_now, other.todo_now);
-        self.future_events.append(&mut other.future_events);
+    pub(super) fn merge(mut self, other: Self) -> Self {
+        self.merge_in_place(other);
         self
     }
 
     pub(super) fn merge_in_place(&mut self, mut other: Self) {
-        self.todo_now = ExecutableReactions::merge_cows(self.todo_now.clone(), other.todo_now);
+        self.todo_now = ExecutableReactions::merge_cows(self.todo_now.take(), other.todo_now);
         self.future_events.append(&mut other.future_events);
     }
 }

--- a/src/scheduler/scheduler_impl.rs
+++ b/src/scheduler/scheduler_impl.rs
@@ -490,7 +490,7 @@ mod parallel_rt_impl {
     pub(super) fn process_batch(ctx: &mut ReactionCtx<'_, '_, '_>, reactors: &mut ReactorVec<'_>, batch: &Level) {
         let reactors_mut = UnsafeSharedPointer(reactors.raw.as_mut_ptr());
 
-        ctx.insides.merge_in_place(
+        ctx.insides.absorb(
             batch
                 .iter()
                 .par_bridge()


### PR DESCRIPTION
This is a quick fix for #4. Previously `ctx.insides` were replaced after executing a tag, instead of merged. I have confirmed that this works, but won't have the time to do proper performance testing for some time. Better working with potentially bad performance than broken I guess.

Closes #4