### PR TITLE
Add support for iterating over interleaved banked multiports

### DIFF
--- a/src/ports.rs
+++ b/src/ports.rs
@@ -105,6 +105,10 @@ impl<T: Sync> PortBank<T> {
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Port<T>> {
         self.ports.iter_mut()
     }
+
+    pub fn len(&self) -> usize {
+        self.ports.len()
+    }
 }
 
 impl<T: Sync> TriggerLike for PortBank<T> {


### PR DESCRIPTION
This extends the `unsafe_iter_bank` macro which is used during the assembly phase to iterate over ports in order to connect them with each other.
Now we can iterate interleaved banked multiports, which is critical for supporting the `interleaved` operator.