### PR TITLE
Clippy fixes

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -107,7 +107,7 @@ impl<T: Sync, K> ReactionTrigger<T> for Action<K, T> {
     #[inline]
     fn use_value_ref<O>(&self, now: &EventTag, _start: &Instant, action: impl FnOnce(Option<&T>) -> O) -> O {
         let inmap: Option<&Option<T>> = self.map.get(&Reverse(*now));
-        let v = inmap.map(|i| i.as_ref()).flatten();
+        let v = inmap.and_then(|i| i.as_ref());
         action(v)
     }
 }

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -61,13 +61,13 @@ impl AssemblyError {
                 debug.fmt_component(upstream),
                 debug.fmt_component(downstream)
             ),
-            CyclicDependencyGraph => format!("Cyclic dependency graph"),
+            CyclicDependencyGraph => "Cyclic dependency graph".to_string(),
             CannotBind(upstream, downstream) => format!(
                 "Cannot bind {} to {}, downstream is already bound",
                 debug.fmt_component(upstream),
                 debug.fmt_component(downstream)
             ),
-            IdOverflow => format!("Overflow when allocating component ID"),
+            IdOverflow => "Overflow when allocating component ID".to_string(),
         }
     }
 }

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -127,7 +127,7 @@ global_id_newtype! {
 
 /// Identifies a component of a reactor using the ID of its container
 /// and a local component ID.
-#[derive(Eq, PartialOrd, PartialEq, Copy, Clone)]
+#[derive(Eq, Copy, Clone)]
 pub(crate) struct GlobalId {
     container: ReactorId,
     local: LocalReactionId,
@@ -179,6 +179,15 @@ impl Hash for GlobalId {
     }
 }
 
+// Since Hash was implemented explicitly, we have to do it for PartialEq as well.
+impl PartialEq for GlobalId {
+    fn eq(&self, other: &Self) -> bool {
+        let self_impl: &GlobalIdImpl = unsafe { std::mem::transmute(self) };
+        let other_impl: &GlobalIdImpl = unsafe { std::mem::transmute(other) };
+        self_impl == other_impl
+    }
+}
+
 // Same reasoning as for Hash, comparison is used to keep Level
 // sets sorted, when feature `vec-id-sets` is enabled.
 impl Ord for GlobalId {
@@ -186,6 +195,12 @@ impl Ord for GlobalId {
         let self_as_impl: &GlobalIdImpl = unsafe { std::mem::transmute(self) };
         let other_as_impl: &GlobalIdImpl = unsafe { std::mem::transmute(other) };
         self_as_impl.cmp(other_as_impl)
+    }
+}
+
+impl PartialOrd for GlobalId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -380,11 +380,11 @@ impl<T: Sync> Port<T> {
             .borrow_mut()
             .insert(downstream.id, Rc::clone(&downstream.upstream_binding));
 
-        let new_binding = Rc::clone(my_class);
+        let new_binding = Rc::clone(&my_class);
 
         mut_downstream_cell.check_cycle(&self.id, &downstream.id)?;
 
-        mut_downstream_cell.set_upstream(my_class);
+        mut_downstream_cell.set_upstream(&my_class);
         *mut_downstream_cell.deref_mut() = new_binding;
         Ok(())
     }
@@ -451,7 +451,7 @@ impl<T: Sync> PortCell<T> {
 
     /// This updates all downstreams to point to the given equiv class instead of `self`
     fn set_upstream(&self, new_binding: &Rc<PortCell<T>>) {
-        for (_, cell_rc) in &*self.downstreams.borrow() {
+        for cell_rc in (*self.downstreams.borrow()).values() {
             cfg_if! {
                 if #[cfg(feature = "no-unsafe")] {
                     let mut ref_mut = cell_rc.borrow_mut();

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -109,6 +109,10 @@ impl<T: Sync> PortBank<T> {
     pub fn len(&self) -> usize {
         self.ports.len()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.ports.is_empty()
+    }
 }
 
 impl<T: Sync> TriggerLike for PortBank<T> {
@@ -156,6 +160,12 @@ impl<'a, T: Sync> ReadablePortBank<'a, T> {
         self.0.ports.len()
     }
 
+    /// Returns true if the bank is empty.
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.0.ports.is_empty()
+    }
+
     /// Returns the ith component
     #[inline(always)]
     pub fn get(&self, i: usize) -> ReadablePort<T> {
@@ -185,6 +195,12 @@ impl<'a, T: Sync> WritablePortBank<'a, T> {
     #[inline(always)]
     pub fn len(&self) -> usize {
         self.0.ports.len()
+    }
+
+    /// Returns true if the bank is empty.
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.0.ports.is_empty()
     }
 
     /// Returns the ith component

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -362,13 +362,13 @@ impl<T: Sync> Port<T> {
         my_class
             .downstreams
             .borrow_mut()
-            .insert(downstream.id.clone(), Rc::clone(&downstream.upstream_binding));
+            .insert(downstream.id, Rc::clone(&downstream.upstream_binding));
 
-        let new_binding = Rc::clone(&my_class);
+        let new_binding = Rc::clone(my_class);
 
         mut_downstream_cell.check_cycle(&self.id, &downstream.id)?;
 
-        mut_downstream_cell.set_upstream(&my_class);
+        mut_downstream_cell.set_upstream(my_class);
         *mut_downstream_cell.deref_mut() = new_binding;
         Ok(())
     }

--- a/src/scheduler/assembly_impl.rs
+++ b/src/scheduler/assembly_impl.rs
@@ -297,7 +297,7 @@ where
             Some(i) => my_debug.derive_bank_item::<Sub>(inst_name, i),
         };
 
-        let subctx = AssemblyCtx::new(&mut self.globals, debug_info);
+        let subctx = AssemblyCtx::new(self.globals, debug_info);
         let subinst = Sub::assemble(args, subctx)?.finish();
         self.children_ids.push(subinst.id());
         Ok(subinst)

--- a/src/scheduler/context.rs
+++ b/src/scheduler/context.rs
@@ -1,4 +1,5 @@
 use std::borrow::{Borrow, BorrowMut};
+use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -689,7 +690,7 @@ impl AsyncCtx<'_, '_, '_> {
 /// An offset from the current event.
 ///
 /// This is to be used with [ReactionCtx::schedule].
-#[derive(Copy, Clone, Hash, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum Offset {
     /// Specify that the trigger will fire at least after
     /// the provided duration.
@@ -737,6 +738,12 @@ impl PartialEq<Self> for Offset {
 }
 
 impl Eq for Offset {}
+
+impl Hash for Offset {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.to_duration().hash(state);
+    }
+}
 
 /// Cleans up a tag
 /// TODO get rid of this!

--- a/src/scheduler/context.rs
+++ b/src/scheduler/context.rs
@@ -289,7 +289,9 @@ where
         T: Sync + 'b,
         W: BorrowMut<WritablePort<'b, T>>,
     {
-        if let Some(v) = value { self.set(port, v) }
+        if let Some(v) = value {
+            self.set(port, v)
+        }
     }
 
     /// Returns true if the given action was triggered at the
@@ -550,6 +552,7 @@ where
 }
 
 /// Info that executing reactions need to make known to the scheduler.
+#[derive(Default)]
 pub(super) struct RContextForwardableStuff<'x> {
     /// Remaining reactions to execute before the wave dies.
     /// Using [Option] and [Cow] optimises for the case where
@@ -564,12 +567,6 @@ pub(super) struct RContextForwardableStuff<'x> {
     /// Events that were produced for a strictly greater
     /// logical time than a current one.
     pub(super) future_events: SmallVec<[Event<'x>; 4]>,
-}
-
-impl Default for RContextForwardableStuff<'_> {
-    fn default() -> Self {
-        Self { todo_now: None, future_events: Default::default() }
-    }
 }
 
 #[cfg(feature = "parallel-runtime")]

--- a/src/scheduler/context.rs
+++ b/src/scheduler/context.rs
@@ -5,8 +5,6 @@ use std::sync::Arc;
 
 use crossbeam_channel::reconnectable::{Receiver, SendError, Sender};
 use crossbeam_utils::thread::{Scope, ScopedJoinHandle};
-#[cfg(feature = "parallel-runtime")]
-use rayon;
 use smallvec::SmallVec;
 
 use super::*;

--- a/src/scheduler/context.rs
+++ b/src/scheduler/context.rs
@@ -289,7 +289,7 @@ where
         T: Sync + 'b,
         W: BorrowMut<WritablePort<'b, T>>,
     {
-        value.map(|v| self.set(port, v));
+        if let Some(v) = value { self.set(port, v) }
     }
 
     /// Returns true if the given action was triggered at the

--- a/src/scheduler/debug.rs
+++ b/src/scheduler/debug.rs
@@ -127,13 +127,13 @@ impl DebugInfoRegistry {
     }
 
     #[inline]
-    pub fn fmt_reaction<'a>(&'a self, id: GlobalReactionId) -> impl Display + 'a {
+    pub fn fmt_reaction(&self, id: GlobalReactionId) -> impl Display + '_ {
         let raw = (id.0.container(), id.0.local().index());
         self.fmt_component_path(raw, self.reaction_labels.get(&id), true)
     }
 
     #[inline]
-    pub fn fmt_component<'a>(&'a self, id: TriggerId) -> impl Display + 'a {
+    pub fn fmt_component(&self, id: TriggerId) -> impl Display + '_ {
         self.fmt_component_path(self.raw_id_of_trigger(id), Some(&self.trigger_infos[id]), false)
     }
 

--- a/src/scheduler/dependencies.rs
+++ b/src/scheduler/dependencies.rs
@@ -423,7 +423,7 @@ impl DataflowInfo {
                 // }
 
                 let mut reactions = ExecutableReactions::new();
-                Self::collect_reactions_rec(&dataflow, trigger, level_info, &mut reactions);
+                Self::collect_reactions_rec(dataflow, trigger, level_info, &mut reactions);
                 result.insert(trigger_id, Arc::new(reactions));
             }
         }
@@ -537,7 +537,7 @@ impl<'a> IntoIterator for &'a Level {
     type IntoIter = <&'a LevelImpl as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
-        (&self.0).into_iter()
+        (&self.0).iter()
     }
 }
 
@@ -775,7 +775,7 @@ pub mod test {
 
         fn new_ports<const N: usize>(&mut self, names: [&'static str; N]) -> [TriggerId; N] {
             let result = array![_ => self.fixture.next_trigger_id.get_and_incr().unwrap(); N];
-            for (i, p) in (&result).into_iter().enumerate() {
+            for (i, p) in (&result).iter().enumerate() {
                 self.fixture.graph.record_port(*p);
                 self.fixture.debug_info.record_trigger(*p, Cow::Borrowed(names[i]));
             }

--- a/src/scheduler/dependencies.rs
+++ b/src/scheduler/dependencies.rs
@@ -513,7 +513,7 @@ impl Level {
         }
     }
 
-    fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -87,7 +87,7 @@ impl DebugInfoProvider<'_> {
     }
 
     #[inline]
-    pub(self) fn display_reaction<'a>(&'a self, id: GlobalReactionId) -> impl Display + 'a {
+    pub(self) fn display_reaction(&self, id: GlobalReactionId) -> impl Display + '_ {
         self.id_registry.fmt_reaction(id)
     }
 }

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -69,7 +69,7 @@ impl DebugInfoProvider<'_> {
     pub(self) fn display_reactions(&self, reactions: &ReactionPlan) -> String {
         use std::fmt::*;
 
-        let mut str = format!("[");
+        let mut str = "[".to_string();
 
         if let Some(reactions) = reactions {
             for (level_no, batch) in reactions.batches() {

--- a/src/scheduler/scheduler_impl.rs
+++ b/src/scheduler/scheduler_impl.rs
@@ -498,8 +498,8 @@ mod parallel_rt_impl {
 
                     CloneableCtx(ctx)
                 })
-                .fold(|| RContextForwardableStuff::default(), |cx1, cx2| cx1.merge(cx2.0.insides))
-                .reduce(|| Default::default(), RContextForwardableStuff::merge),
+                .fold(RContextForwardableStuff::default, |cx1, cx2| cx1.merge(cx2.0.insides))
+                .reduce(Default::default, RContextForwardableStuff::merge),
         );
     }
 

--- a/src/scheduler/scheduler_impl.rs
+++ b/src/scheduler/scheduler_impl.rs
@@ -41,6 +41,7 @@ use crate::*;
 /// LFC uses target properties to set them. With the "cli"
 /// feature, generated programs also feature CLI options to
 /// override the defaults at runtime.
+#[derive(Default)]
 pub struct SchedulerOptions {
     /// If true, we won't shut down the scheduler as soon as
     /// the event queue is empty, provided there are still
@@ -61,17 +62,6 @@ pub struct SchedulerOptions {
     /// If true, dump the dependency graph to a file before
     /// starting execution.
     pub dump_graph: bool,
-}
-
-impl Default for SchedulerOptions {
-    fn default() -> Self {
-        Self {
-            keep_alive: false,
-            timeout: None,
-            threads: 0,
-            dump_graph: false,
-        }
-    }
 }
 
 // Macros are placed a bit out of order to avoid exporting them

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -40,7 +40,7 @@ macro_rules! join_to {
         join_to!($f, $iter, $sep, $prefix, $suffix, |x| format!("{}", x))
     };
     ($f:expr, $iter:expr, $sep:literal, $prefix:literal, $suffix:literal, $display:expr) => {{
-        crate::util::do_write($f, $iter, $sep, $prefix, $suffix, $display)
+        $crate::util::do_write($f, $iter, $sep, $prefix, $suffix, $display)
     }};
 }
 
@@ -264,7 +264,7 @@ pub fn try_parse_duration(t: &str) -> Result<Duration, String> {
     let mut chars = t.char_indices().skip_while(|(_, c)| c.is_numeric());
 
     if let Some((num_end, _)) = &chars.next() {
-        let magnitude: u64 = (&t)[0..*num_end].parse::<u64>().map_err(|e| format!("{}", e))?;
+        let magnitude: u64 = t[0..*num_end].parse::<u64>().map_err(|e| format!("{}", e))?;
 
         let unit = t[*num_end..].trim();
 
@@ -275,7 +275,7 @@ pub fn try_parse_duration(t: &str) -> Result<Duration, String> {
         Ok(duration)
     } else if t != "0" {
         // no unit
-        if t.len() > 0 {
+        if !t.is_empty() {
             Err("time unit required".into())
         } else {
             Err("cannot parse empty string".into())

--- a/src/util/vecmap.rs
+++ b/src/util/vecmap.rs
@@ -22,6 +22,7 @@
  * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+use std::cmp::Ordering;
 use std::fmt::{Debug, Display, Formatter};
 
 /// A sparse map representation over a totally ordered key type.
@@ -56,11 +57,13 @@ where
         debug_assert!(self.is_valid_keyref(&key.as_ref()));
         let KeyRef { min_idx, key } = key;
         for i in min_idx..self.v.len() {
-            if self.v[i].0 == key {
-                return Entry::Occupied(OccupiedEntry { map: self, index: i, key });
-            } else if self.v[i].0 > key {
-                assert!(i >= 1, "keyref was invalid"); // otherwise min_idx
-                return Entry::Vacant(VacantEntry { map: self, index: i, key });
+            match self.v[i].0.cmp(&key) {
+                Ordering::Equal => return Entry::Occupied(OccupiedEntry { map: self, index: i, key }),
+                Ordering::Greater => {
+                    assert!(i >= 1, "keyref was invalid"); // otherwise min_idx
+                    return Entry::Vacant(VacantEntry { map: self, index: i, key });
+                }
+                _ => {}
             }
         }
         let i = self.v.len();

--- a/src/util/vecmap.rs
+++ b/src/util/vecmap.rs
@@ -64,7 +64,7 @@ where
             }
         }
         let i = self.v.len();
-        return Entry::Vacant(VacantEntry { map: self, index: i, key });
+        Entry::Vacant(VacantEntry { map: self, index: i, key })
     }
 
     /// Finds entry reference, either directly associated with `min_key_inclusive`, or the entry with the


### PR DESCRIPTION
This resolves almost every Clippy warning and error. The thing I'm a bit worried about is that runtime behaviour was reliant on the disagreeing trait definitions for `PartialOrd`, `PartialEq`, and `Hash` which was fixed in 875f2b508d9ecf4f6aec335be21f3ad0635a8ec9. These were outright errors reported by Clippy. Here is an [example](https://rust-lang.github.io/rust-clippy/master/index.html#derive_hash_xor_eq) for such a lint.

I'll run all benchmarks next week with these changes and see if anything breaks.