### PR TITLE
Add clippy to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: stable
+        toolchain: nightly
         override: true
         components: rustfmt, clippy
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,17 +43,33 @@ jobs:
         publish_dir: target/doc
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  format:
+  lints:
+    name: Lints
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
+    - name: Checkout sources
+      uses: actions/checkout@v2
+
+    - name: Install stable toolchain
+      uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
-        components: rustfmt
-    - name: Check format
-      run: cargo +nightly fmt -- --check
+        toolchain: stable
+        override: true
+        components: rustfmt, clippy
+
+    - name: Run cargo fmt
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check
+
+    - name: Run cargo clippy
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: --all-features -- -D warnings
 
   fetch-lf:
     uses: lf-lang/lingua-franca/.github/workflows/extract-ref.yml@master

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 10

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -410,6 +410,11 @@ enum BindStatus {
     Bound,
 }
 
+#[cfg(feature = "no-unsafe")]
+type DownstreamsSafe<T> = AtomicRefCell<HashMap<PortId, Rc<AtomicRefCell<Rc<PortCell<T>>>>>>;
+#[cfg(not(feature = "no-unsafe"))]
+type DownstreamsUnsafe<T> = AtomicRefCell<HashMap<PortId, Rc<UnsafeCell<Rc<PortCell<T>>>>>>;
+
 /// This is the internal cell type that is shared by ports.
 struct PortCell<T: Sync> {
     /// Cell for the value.
@@ -435,9 +440,9 @@ struct PortCell<T: Sync> {
     /// - if you then try binding C -> A, then we can know
     /// that C is in the downstream of A, indicating that there is a cycle.
     #[cfg(feature = "no-unsafe")]
-    downstreams: AtomicRefCell<HashMap<PortId, Rc<AtomicRefCell<Rc<PortCell<T>>>>>>,
+    downstreams: DownstreamsSafe<T>,
     #[cfg(not(feature = "no-unsafe"))]
-    downstreams: AtomicRefCell<HashMap<PortId, Rc<UnsafeCell<Rc<PortCell<T>>>>>>,
+    downstreams: DownstreamsUnsafe<T>,
 }
 
 impl<T: Sync> PortCell<T> {


### PR DESCRIPTION
This contains one last Clippy fix, a very simple clippy configuration so that we can keep the function structure we currently have and a CI configuration. The CI configuration merges the Clippy linting step with the formatting step ~~and now uses Rust stable~~.

Closes #21.