### PR TITLE
Compat with rust 1.89 nightly

### DIFF
--- a/src/scheduler/assembly_impl.rs
+++ b/src/scheduler/assembly_impl.rs
@@ -175,7 +175,7 @@ where
         // makes this whole debug info recording very complicated.
         let id = self.globals.reactor_id.get_and_incr();
         let debug = self.debug.take().expect("unreachable - can only call assemble_self once");
-        trace!("Children of {}: {:?}", debug.to_string(), self.children_ids);
+        trace!("Children of {}: {:?}", debug, self.children_ids);
         self.globals.debug_info.record_reactor(id, debug);
         for child in self.children_ids.drain(..) {
             self.globals.debug_info.record_reactor_container(id, child);

--- a/src/scheduler/assembly_impl.rs
+++ b/src/scheduler/assembly_impl.rs
@@ -546,6 +546,6 @@ macro_rules! unsafe_iter_bank {
             bank_idx += 1;
             Some((bank_idx_copy, multiport_idx))
         });
-        iter.map(move |(i, j)| unsafe { &mut (*__ptr.add(i)).$field_name[j] })
+        iter.map(move |(i, j)| unsafe { &mut (&mut *__ptr.add(i)).$field_name[j] })
     }};
 }


### PR DESCRIPTION
Fix a new error appearing in latest nightly versions.

Related to #52, https://github.com/lf-lang/benchmarks-lingua-franca/pull/70

